### PR TITLE
change graphviz path following refactor of buildback-graphviz

### DIFF
--- a/post_compile
+++ b/post_compile
@@ -16,9 +16,9 @@ puts-warn() {
 
 
 # Set graphviz path
-export PATH=${BUILD_DIR}/heroku-buildpack-graphviz/usr/bin:${PATH}
-export GRAPHVIZ_DOT=${BUILD_DIR}/heroku-buildpack-graphviz/usr/bin/dot
-export LD_LIBRARY_PATH=${BUILD_DIR}/heroku-buildpack-graphviz/usr/lib:${BUILD_DIR}/.heroku/vendor/lib/:${LD_LIBRARY_PATH}
+export PATH=${BUILD_DIR}/.heroku-buildpack-graphviz/usr/bin:${PATH}
+export GRAPHVIZ_DOT=${BUILD_DIR}/.heroku-buildpack-graphviz/usr/bin/dot
+export LD_LIBRARY_PATH=${BUILD_DIR}/.heroku-buildpack-graphviz/usr/lib/x86_64-linux-gnu:${BUILD_DIR}/.heroku/vendor/lib/:${LD_LIBRARY_PATH}
 
 puts-step "Setting up Sphinx environment"
 


### PR DESCRIPTION
fix graphviz path after [refactor on buildpack-graphviz](https://github.com/weibeld/heroku-buildpack-graphviz/commit/9bb4a5218926a1b7ae35fc7b6f5ecc7841c17bc4) and stack upgrade (see https://github.com/weibeld/heroku-buildpack-graphviz/issues/9) 